### PR TITLE
fix: omit pages source block when build_type is workflow

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -140,9 +140,15 @@ resource "github_repository" "repository" {
     for_each = var.pages != null ? [true] : []
 
     content {
-      source {
-        branch = var.pages.branch
-        path   = try(var.pages.path, "/")
+      # For workflow-based Pages (GitHub Actions) the API stores no branch/path
+      # source, so only render `source` for legacy (or unset) build types to
+      # avoid perpetual drift.
+      dynamic "source" {
+        for_each = try(var.pages.build_type, null) != "workflow" ? [true] : []
+        content {
+          branch = var.pages.branch
+          path   = try(var.pages.path, "/")
+        }
       }
       cname      = try(var.pages.cname, null)
       build_type = try(var.pages.build_type, null)


### PR DESCRIPTION
## Problem

For workflow-based GitHub Pages (`build_type = "workflow"`), Pages are deployed via GitHub Actions and the GitHub API does **not** persist a branch/path `source`. The module currently always renders the `source` block whenever `var.pages != null`, so on every refresh the provider reads `source = null` from the API and the plan wants to re-add it:

```hcl
~ pages {
  + source {
      + branch = "develop"
      + path   = "/"
    }
}
```

This is a perpetual, non-converging diff — `apply` does not fix it because the API drops the source for workflow builds.

## Change

Render the `pages` `source` block only when `build_type != "workflow"`, via a `dynamic "source"` block:

```hcl
dynamic "source" {
  for_each = try(var.pages.build_type, null) != "workflow" ? [true] : []
  content {
    branch = var.pages.branch
    path   = try(var.pages.path, "/")
  }
}
```

- `build_type = "workflow"` → no `source` block → matches the API state → no drift.
- `build_type = "legacy"` or unset → `source` rendered from `branch`/`path` as before → **no behaviour change**. Existing `test/unit-complete` (uses `pages = { branch, path }` without `build_type`) stays green.
- `var.pages.branch` is now only evaluated inside the dynamic content, so `branch` is no longer required for workflow builds.

## Notes

- Targets `extended` since that is the branch consumers pin via `?ref=extended`.
- `terraform validate` passes.